### PR TITLE
Consume read_chunk event only if it concerns virtual files

### DIFF
--- a/plugin_tests/file_test.py
+++ b/plugin_tests/file_test.py
@@ -339,7 +339,6 @@ class FileOperationsTestCase(base.TestCase):
         file = resp.json
 
         self.assertHasKeys(file, ["itemId"])
-        self.assertEqual(file["assetstoreId"], None)
         self.assertEqual(file["name"], name)
         self.assertEqual(file["size"], len(chunk1 + chunk2))
 

--- a/server/rest/virtual_file.py
+++ b/server/rest/virtual_file.py
@@ -196,7 +196,8 @@ class VirtualFile(VirtualObject):
             return upload
 
     @access.user(scope=TokenScope.DATA_WRITE)
-    def read_chunk(self, event):
+    @validate_event(level=AccessType.WRITE)
+    def read_chunk(self, event, path, root, user=None):
         params = event.info["params"]
         if "chunk" in params:
             chunk = params["chunk"]
@@ -209,7 +210,8 @@ class VirtualFile(VirtualObject):
         else:
             chunk = RequestBodyStream(cherrypy.request.body)
 
-        user = self.getCurrentUser()
+        if not user:
+            user = self.getCurrentUser()
         offset = int(params.get("offset", 0))
         upload = Upload().load(params["uploadId"])
 


### PR DESCRIPTION
Before `virtual_resources.read_chunk` was always triggered, no matter where file was being uploaded, which of course horribly broke Girder and yet went unnoticed...