### PR TITLE
Add functionality missing for wt_home_dirs to work properly

### DIFF
--- a/plugin_tests/file_test.py
+++ b/plugin_tests/file_test.py
@@ -433,7 +433,7 @@ class FileOperationsTestCase(base.TestCase):
         )
         self.assertStatus(resp, 500)
         self.assertEqual(
-            resp.json["message"], "Exception: Exception('Failed to store upload.',)",
+            resp.json["message"], "Exception: Exception('Failed to store upload.')",
         )
         dest_dir.chmod(0o775)
 

--- a/plugin_tests/item_test.py
+++ b/plugin_tests/item_test.py
@@ -348,6 +348,30 @@ class ItemOperationsTestCase(base.TestCase):
         self.assertTrue(file_new.exists())
         file_new.unlink()
 
+    def test_copy_existing_name(self):
+        from girder.plugins.virtual_resources.rest import VirtualObject
+
+        root_path = pathlib.Path(self.private_folder["fsPath"])
+        file1 = root_path / "existing.txt"
+        file1_contents = b"Blah Blah Blah"
+        with file1.open(mode="wb") as fp:
+            fp.write(file1_contents)
+        item_id = VirtualObject.generate_id(file1, self.private_folder["_id"])
+
+        resp = self.request(
+            path="/item/{}/copy".format(item_id),
+            method="POST",
+            user=self.users["admin"],
+            params={},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json["name"], "existing.txt (1)")
+
+        self.assertStatusOk(resp)
+        self.assertTrue((root_path / "existing.txt (1)").is_file())
+        file1.unlink()
+        (root_path / "existing.txt (1)").unlink()
+
     def tearDown(self):
         for folder in (self.public_folder, self.private_folder, self.regular_folder):
             Folder().remove(folder)

--- a/plugin_tests/item_test.py
+++ b/plugin_tests/item_test.py
@@ -264,6 +264,90 @@ class ItemOperationsTestCase(base.TestCase):
         file1.with_name("copy").unlink()
         cors_file.unlink()
 
+    def test_move_item(self):
+        from girder.plugins.virtual_resources.rest import VirtualObject
+
+        root_path = pathlib.Path(self.public_folder["fsPath"])
+        subdir = root_path / "subdir"
+        subdir.mkdir()
+        file1 = subdir / "to_be_moved"
+        file_contents = b"hello world asdfadsf\n"
+        with file1.open(mode="wb") as fp:
+            fp.write(file_contents)
+        folder_id = VirtualObject.generate_id(subdir, self.public_folder["_id"])
+        item_id = VirtualObject.generate_id(file1, self.public_folder["_id"])
+
+        # Move with the same name (noop)
+        resp = self.request(
+            path="/item/{}".format(item_id),
+            method="PUT",
+            user=self.users["admin"],
+            params={"name": file1.name, "folderId": folder_id},
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue(file1.exists())
+
+        # Move within the same folder
+        resp = self.request(
+            path="/item/{}".format(item_id),
+            method="PUT",
+            user=self.users["admin"],
+            params={"name": "after_move", "folderId": folder_id},
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue((subdir / "after_move").exists())
+        self.assertFalse(file1.exists())
+
+        # Move to a different folder
+        file1 = subdir / "after_move"
+        item_id = VirtualObject.generate_id(file1, self.public_folder["_id"])
+        resp = self.request(
+            path="/item/{}".format(item_id),
+            method="PUT",
+            user=self.users["admin"],
+            params={"name": "after_move", "folderId": self.private_folder["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertFalse(file1.exists())
+        root_path = pathlib.Path(self.private_folder["fsPath"])
+        file_new = root_path / "after_move"
+        item_id = VirtualObject.generate_id(file_new, self.private_folder["_id"])
+
+        self.assertTrue(file_new.is_file())
+        with open(file_new.as_posix(), "rb") as fp:
+            self.assertEqual(fp.read(), file_contents)
+
+        # Try to move not into mapping and fail
+        resp = self.request(
+            path="/item/{}".format(item_id),
+            method="PUT",
+            user=self.users["sally"],
+            params={
+                "name": "after_move",
+                "folderId": str(self.regular_folder["_id"]),
+                "parentType": "folder",
+            },
+            exception=True,
+        )
+        self.assertStatus(resp, 500)
+        self.assertEqual(
+            resp.json["message"],
+            "Folder {} is not a mapping.".format(self.regular_folder["_id"]),
+        )
+
+        # move it back to subdir in a mapping
+        resp = self.request(
+            path="/item/{}".format(item_id),
+            method="PUT",
+            user=self.users["admin"],
+            params={"name": "final_move", "folderId": folder_id},
+        )
+        self.assertStatusOk(resp)
+        self.assertFalse(file_new.exists())
+        file_new = subdir / "final_move"
+        self.assertTrue(file_new.exists())
+        file_new.unlink()
+
     def tearDown(self):
         for folder in (self.public_folder, self.private_folder, self.regular_folder):
             Folder().remove(folder)

--- a/server/rest/virtual_item.py
+++ b/server/rest/virtual_item.py
@@ -85,7 +85,9 @@ class VirtualItem(VirtualObject):
                 try:
                     dst_path = pathlib.Path(dst_root["fsPath"])
                 except KeyError:
-                    raise GirderException("Folder {} is not a mapping.".format(parentId))
+                    raise GirderException(
+                        "Folder {} is not a mapping.".format(parentId)
+                    )
                 dst_root_id = str(dst_root["_id"])
             self.is_dir(dst_path, dst_root_id)
             new_path = dst_path / name
@@ -126,6 +128,12 @@ class VirtualItem(VirtualObject):
         else:
             new_root = root
 
+        checkName = (new_dirname / name) == path
+        n = 0
+        while checkName:
+            n += 1
+            name = "%s (%d)" % (path.name, n)
+            checkName = (new_dirname / name).exists()
         new_path = new_dirname / name
         shutil.copy(path.as_posix(), new_path.as_posix())
         event.preventDefault().addResponse(

--- a/server/rest/virtual_item.py
+++ b/server/rest/virtual_item.py
@@ -65,8 +65,32 @@ class VirtualItem(VirtualObject):
     @validate_event(level=AccessType.WRITE)
     def rename_item(self, event, path, root, user=None):
         self.is_file(path, root["_id"])
-        new_path = path.with_name(event.info["params"]["name"])
-        path.rename(new_path)
+        source = self.vItem(path, root)
+
+        params = event.info.get("params", {})
+        name = params.get("name", path.name)
+        parentId = params.get("folderId", source["folderId"])
+
+        if parentId == source["folderId"]:
+            if path.name == name:
+                new_path = path
+            else:
+                new_path = path.with_name(name)
+                path.rename(new_path)
+        else:
+            if str(parentId).startswith("wtlocal:"):
+                dst_path, dst_root_id = self.path_from_id(parentId)
+            else:
+                dst_root = Folder().load(parentId, force=True, exc=True)
+                try:
+                    dst_path = pathlib.Path(dst_root["fsPath"])
+                except KeyError:
+                    raise GirderException("Folder {} is not a mapping.".format(parentId))
+                dst_root_id = str(dst_root["_id"])
+            self.is_dir(dst_path, dst_root_id)
+            new_path = dst_path / name
+            shutil.move(path.as_posix(), new_path.as_posix())
+
         event.preventDefault().addResponse(
             Item().filter(self.vItem(new_path, root), user=user)
         )

--- a/server/rest/virtual_resource.py
+++ b/server/rest/virtual_resource.py
@@ -107,13 +107,12 @@ class VirtualResource(VirtualObject):
                     )
                 else:
                     name = source_path.name
-                    if source_path == (path / source_path.name):
-                        checkName = source_path.name == name
-                        n = 0
-                        while checkName:
-                            n += 1
-                            name = "%s (%d)" % (source_path.name, n)
-                            checkName = (path / name).exists()
+                    checkName = source_path == (path / name)
+                    n = 0
+                    while checkName:
+                        n += 1
+                        name = "%s (%d)" % (source_path.name, n)
+                        checkName = (path / name).exists()
                     shutil.copy(source_path.as_posix(), (path / name).as_posix())
                 ctx.update(increment=1)
 
@@ -170,7 +169,7 @@ class VirtualResource(VirtualObject):
     def _get_vobject(self, document, path, i):
         pathArray = split(path)
         root = document
-        fspath = os.path.join(document["fsPath"], "/".join(pathArray[3 + i :]))
+        fspath = os.path.join(document["fsPath"], "/".join(pathArray[3 + i:]))
         fspath = pathlib.Path(fspath)
         if not fspath.exists():
             raise ValidationException("Path not found: %s" % path)


### PR DESCRIPTION
New features:
* GET /resource/lookup
* PUT /{folder,item}/:id now supports moving instead of just renaming
* Copying file `foo` in place properly creates `foo (1)`