### PR TITLE
Use stat.mtime/ctime for reporting root folder properties

### DIFF
--- a/server/rest/__init__.py
+++ b/server/rest/__init__.py
@@ -86,11 +86,16 @@ class VirtualObject(Resource):
             )
 
     def vFolder(self, path, root):
-        if path == pathlib.Path(root["fsPath"]):
-            return root
-
         self.is_dir(path, root["_id"])
         stat = path.stat()
+
+        if path == pathlib.Path(root["fsPath"]):
+            # We want actual mtime/ctime from disk
+            root.update({
+                "created": datetime.datetime.fromtimestamp(stat.st_ctime),
+                "updated": datetime.datetime.fromtimestamp(stat.st_mtime),
+            })
+            return root
 
         if path.parent == pathlib.Path(root["fsPath"]):
             parentId = root["_id"]


### PR DESCRIPTION
When content of the virtual resource root changes its mtime is not updated in girder's db. This PR ensures that any API call involving root gets `created` and `updated` fields read from disk.

### Note
With regards to https://github.com/whole-tale/gwvolman/issues/121 : it only fixes it partially, since mtime for workspace is only modified if a file or a child folder is modified. However, if change happens somewhere deeper in the hierarchy, it won't affect the root.