### PR TITLE
fix copying in place. Fixes #13

### DIFF
--- a/plugin_tests/folder_test.py
+++ b/plugin_tests/folder_test.py
@@ -451,23 +451,22 @@ class FolderOperationsTestCase(base.TestCase):
             path="/folder/{}/copy".format(folder_id),
             method="POST",
             user=self.users["sally"],
-            params={},
-            exception=True,
-        )
-        self.assertStatus(resp, 500)
-        self.assertEqual(
-            resp.json["message"],
-            "Folder '{}' already exists at {}".format(dir1.name, dir1),
-        )
-
-        resp = self.request(
-            path="/folder/{}/copy".format(folder_id),
-            method="POST",
-            user=self.users["sally"],
             params={"name": "new_copy"},
         )
         self.assertStatus(resp, 403)
         self.assertFalse((dir1.with_name("new_copy") / file1.name).is_file())
+
+        resp = self.request(
+            path="/folder/{}/copy".format(folder_id),
+            method="POST",
+            user=self.users["admin"],
+            params={},
+            exception=True,
+        )
+        self.assertStatus(resp, 200)
+        new_folder = resp.json
+        self.assertEqual(new_folder["name"], "source_folder (1)")
+        self.assertTrue((dir1.with_name("source_folder (1)") / file1.name).is_file())
 
         resp = self.request(
             path="/folder/{}/copy".format(folder_id),

--- a/server/rest/__init__.py
+++ b/server/rest/__init__.py
@@ -13,6 +13,17 @@ from girder.models.folder import Folder
 from girder.models.upload import Upload
 
 
+def ensure_unique_path(dirname, name):
+    checkName = (dirname / name).exists()
+    new_name = name
+    n = 0
+    while checkName:
+        n += 1
+        new_name = "%s (%d)" % (name, n)
+        checkName = (dirname / new_name).exists()
+    return dirname / new_name
+
+
 def validate_event(level=AccessType.READ):
     def validation(func):
         def wrapper(self, event):

--- a/server/rest/virtual_resource.py
+++ b/server/rest/virtual_resource.py
@@ -23,7 +23,7 @@ from girder.utility.path import lookUpToken, split, getResourcePath
 from girder.utility.model_importer import ModelImporter
 from girder.utility.progress import ProgressContext
 
-from . import VirtualObject, validate_event
+from . import VirtualObject, validate_event, ensure_unique_path
 
 
 class EmptyDocument(Exception):
@@ -112,13 +112,8 @@ class VirtualResource(VirtualObject):
                     )
                 else:
                     name = source_path.name
-                    checkName = source_path == (path / name)
-                    n = 0
-                    while checkName:
-                        n += 1
-                        name = "%s (%d)" % (source_path.name, n)
-                        checkName = (path / name).exists()
-                    shutil.copy(source_path.as_posix(), (path / name).as_posix())
+                    new_path = ensure_unique_path(path, name)
+                    shutil.copy(source_path.as_posix(), new_path.as_posix())
                 ctx.update(increment=1)
 
     @access.user(scope=TokenScope.DATA_WRITE)


### PR DESCRIPTION
* Refactor code responsible for name/path sanitization in case target resource exists.
* Fix the behavior of COPY operation when parentId is not provided (should create a copy in the same folder, instead of root directory)

Test case in #13 (note the same behavior happened for folders too, it's also fixed by this PR.)