### PR TITLE
Respect 'name' in folder/item list. Fixes #16

### DIFF
--- a/plugin_tests/item_test.py
+++ b/plugin_tests/item_test.py
@@ -119,6 +119,24 @@ class ItemOperationsTestCase(base.TestCase):
             path="/item",
             method="GET",
             user=self.users["admin"],
+            params={"parentType": "folder", "parentId": str(parentId), "name": "nope"},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json), 0)
+
+        resp = self.request(
+            path="/item",
+            method="GET",
+            user=self.users["admin"],
+            params={"parentType": "folder", "parentId": str(parentId), "name": item["name"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json), 1)
+
+        resp = self.request(
+            path="/item",
+            method="GET",
+            user=self.users["admin"],
             params={"parentType": "folder", "parentId": str(parentId)},
         )
         self.assertStatusOk(resp)
@@ -377,7 +395,7 @@ class ItemOperationsTestCase(base.TestCase):
         self.assertStatus(resp, 400)
         folder = resp.json
         self.assertEqual(
-            resp.json,
+            folder,
             {
                 "type": "validation",
                 "message": "An item with that name already exists here.",

--- a/server/rest/virtual_folder.py
+++ b/server/rest/virtual_folder.py
@@ -58,12 +58,21 @@ class VirtualFolder(VirtualObject):
     @validate_event(level=AccessType.READ)
     def get_child_folders(self, event, path, root, user=None):
         params = event.info["params"]
+        name = params.get("name")
         offset = int(params.get("offset", 0))
         limit = int(params.get("limit", 50))
         sort_key = params.get("sort", "lowerName")
         reverse = int(params.get("sortdir", pymongo.ASCENDING)) == pymongo.DESCENDING
 
-        folders = [self.vFolder(obj, root) for obj in path.iterdir() if obj.is_dir()]
+        # TODO: implement "text"
+        if name:
+            if (path / name).is_dir():
+                folders = [self.vFolder(path / name, root)]
+            else:
+                folders = []
+        else:
+            folders = [self.vFolder(obj, root) for obj in path.iterdir() if obj.is_dir()]
+
         folders = sorted(folders, key=itemgetter(sort_key), reverse=reverse)
         upper_bound = limit + offset if limit > 0 else None
         response = [

--- a/server/rest/virtual_item.py
+++ b/server/rest/virtual_item.py
@@ -40,10 +40,17 @@ class VirtualItem(VirtualObject):
         params = event.info["params"]
         offset = int(params.get("offset", 0))
         limit = int(params.get("limit", 50))
+        name = params.get("name")
         sort_key = params.get("sort", "lowerName")
         reverse = int(params.get("sortdir", pymongo.ASCENDING)) == pymongo.DESCENDING
 
-        items = [self.vItem(obj, root) for obj in path.iterdir() if obj.is_file()]
+        if name:
+            if (path / name).is_file():
+                items = [self.vItem(path / name, root)]
+            else:
+                items = []
+        else:
+            items = [self.vItem(obj, root) for obj in path.iterdir() if obj.is_file()]
         items = sorted(items, key=itemgetter(sort_key), reverse=reverse)
         upper_bound = limit + offset if limit > 0 else None
         response = [


### PR DESCRIPTION
`name` parameter was ignored. Now it's not...

### How to test

1. See #16