### PR TITLE
Raise exception during rename if target exists. Fixes #18

### DIFF
--- a/plugin_tests/folder_test.py
+++ b/plugin_tests/folder_test.py
@@ -196,12 +196,10 @@ class FolderOperationsTestCase(base.TestCase):
             params={"name": dir1.name},
             exception=True,
         )
-        self.assertStatus(resp, 500)
+        self.assertStatus(resp, 400)
         self.assertEqual(
             resp.json["message"],
-            "Folder '{}' already exists in {}".format(
-                dir1.name, self.public_folder["_id"]
-            ),
+            "A folder or file with that name already exists here."
         )
 
         new_root_path = pathlib.Path(self.private_folder["fsPath"])

--- a/plugin_tests/item_test.py
+++ b/plugin_tests/item_test.py
@@ -295,15 +295,18 @@ class ItemOperationsTestCase(base.TestCase):
         folder_id = VirtualObject.generate_id(subdir, self.public_folder["_id"])
         item_id = VirtualObject.generate_id(file1, self.public_folder["_id"])
 
-        # Move with the same name (noop)
+        # Move with the same name (400)
         resp = self.request(
             path="/item/{}".format(item_id),
             method="PUT",
             user=self.users["admin"],
             params={"name": file1.name, "folderId": folder_id},
         )
-        self.assertStatusOk(resp)
-        self.assertTrue(file1.exists())
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json["message"],
+            "A folder or file with that name already exists here."
+        )
 
         # Move within the same folder
         resp = self.request(

--- a/server/rest/__init__.py
+++ b/server/rest/__init__.py
@@ -13,6 +13,13 @@ from girder.models.folder import Folder
 from girder.models.upload import Upload
 
 
+def bail_if_exists(path):
+    if path.exists():
+        raise ValidationException(
+            "A folder or file with that name already exists here.", "name"
+        )
+
+
 def ensure_unique_path(dirname, name):
     checkName = (dirname / name).exists()
     new_name = name

--- a/server/rest/virtual_file.py
+++ b/server/rest/virtual_file.py
@@ -18,7 +18,7 @@ from girder.models.folder import Folder
 from girder.models.upload import Upload
 from girder.utility import RequestBodyStream, assetstore_utilities
 
-from . import VirtualObject, validate_event
+from . import VirtualObject, validate_event, bail_if_exists
 
 
 BUF_SIZE = 65536
@@ -104,6 +104,7 @@ class VirtualFile(VirtualObject):
     def rename_file(self, event, path, root, user=None):
         self.is_file(path, root["_id"])
         new_path = path.with_name(event.info["params"]["name"])
+        bail_if_exists(new_path)
         path.rename(new_path)
         event.preventDefault().addResponse(
             File().filter(self.vFile(new_path, root), user=user)


### PR DESCRIPTION
Do not allow to rename folder/file if there's already folder/file with the same name.

### How to test?
1. Go to Home and try all the possible combinations:
   * folder1, folder2 => folder1
   * folder1, item1 => folder1
   * item1, folder1 => item1
   * item1, item2 => item2
2. Create a subfolder in Home. Repeat 1. there. 