### PR TITLE
Check if parent folder exists in GET /item

### DIFF
--- a/server/rest/virtual_item.py
+++ b/server/rest/virtual_item.py
@@ -37,6 +37,7 @@ class VirtualItem(VirtualObject):
     @access.public(scope=TokenScope.DATA_READ)
     @validate_event(level=AccessType.READ)
     def get_child_items(self, event, path, root, user=None):
+        self.is_dir(path, root["_id"])
         params = event.info["params"]
         offset = int(params.get("offset", 0))
         limit = int(params.get("limit", 50))


### PR DESCRIPTION
Fixes:

```
 15 [2022-09-28 08:34:21,655] ERROR: 500 Error
 16 Traceback (most recent call last):
 17   File "/girder/girder/api/rest.py", line 630, in endpointDecorator
 18     val = fun(self, path, params)
 19   File "/girder/girder/api/rest.py", line 1216, in GET
 20     return self.handleRoute('GET', path, params)
 21   File "/girder/girder/api/rest.py", line 964, in handleRoute
 22     event = events.trigger('.'.join((eventPrefix, 'before')),
 23   File "/girder/girder/events.py", line 314, in trigger
 24     handler['handler'](e)
 25   File "/girder/plugins/virtual_resources/server/rest/__init__.py", line 64, in wrapper
 26     func(self, event, path, root, user=user)
 27   File "/girder/plugins/virtual_resources/server/rest/virtual_item.py", line 53, in get_child_items
 28     items = [self.vItem(obj, root) for obj in path.iterdir() if obj.is_file()]
 29   File "/girder/plugins/virtual_resources/server/rest/virtual_item.py", line 53, in <listcomp>
 30     items = [self.vItem(obj, root) for obj in path.iterdir() if obj.is_file()]
 31   File "/usr/local/lib/python3.9/pathlib.py", line 1150, in iterdir
 32     for name in self._accessor.listdir(self):
 33 FileNotFoundError: [Errno 2] No such file or directory: '/tmp/data/homes/b/b.webster/FolderOne (1)'
 34 Additional info:
 35   Request URL: GET https://girder.wholetale.org/api/v1/item
 36   Query string: limit=0&folderId=wtlocal%3AL3RtcC9kYXRhL2hvbWVzL2IvYi53ZWJzdGVyL0ZvbGRlck9uZSAoMSl8NjJiYzQ5NDA0YzczYjQwNzMyNDc3NGIw
 37   Remote IP: 10.0.1.5
```